### PR TITLE
Return x when converting public key to buffer

### DIFF
--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -326,28 +326,10 @@ PublicKey.prototype.toObject = PublicKey.prototype.toJSON = function toObject() 
  */
 PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
   var x = this.point.getX();
-  var y = this.point.getY();
 
-  var xbuf = x.toBuffer({
+  return x.toBuffer({
     size: 32
   });
-  var ybuf = y.toBuffer({
-    size: 32
-  });
-
-  var prefix;
-  if (!this.compressed) {
-    prefix = Buffer.from([0x04]);
-    return Buffer.concat([prefix, xbuf, ybuf]);
-  } else {
-    var odd = ybuf[ybuf.length - 1] % 2;
-    if (odd) {
-      prefix = Buffer.from([0x03]);
-    } else {
-      prefix = Buffer.from([0x02]);
-    }
-    return Buffer.concat([prefix, xbuf]);
-  }
 };
 
 /**


### PR DESCRIPTION
The schnorr public key doesn't have a DER encoding, so we just use the same as encoding as Bitcoin and use the public key x coordinate when encoding it